### PR TITLE
Add the --insecure option

### DIFF
--- a/bin/marathon
+++ b/bin/marathon
@@ -146,6 +146,8 @@ EOS
       :short => '-U', :type => String
     opt :password, 'Password to authenticate against Marathon (optional, default unset, or MARATHON_PASSWORD).',
       :short => '-P', :type => String
+    opt :insecure, 'Ignore certificate verification failure (optional, default false, or MARATHON_INSECURE).',
+      :short => '-I'
     stop_on SUB_COMMANDS
   end
   return global_opts

--- a/lib/marathon.rb
+++ b/lib/marathon.rb
@@ -92,6 +92,7 @@ module Marathon
     opts = {}
     opts[:username] = ENV['MARATHON_USER'] if ENV['MARATHON_USER']
     opts[:password] = ENV['MARATHON_PASSWORD'] if ENV['MARATHON_PASSWORD']
+    opts[:insecure] = ENV['MARATHON_INSECURE'] == 'true' if ENV['MARATHON_INSECURE']
     opts
   end
 

--- a/lib/marathon/connection.rb
+++ b/lib/marathon/connection.rb
@@ -29,6 +29,13 @@ class Marathon::Connection
       @options.delete(:username)
       @options.delete(:password)
     end
+
+    # The insecure option allows ignoring bad (or self-signed) SSL
+    # certificates.
+    if @options[:insecure]
+      @options[:verify] = false
+      @options.delete(:insecure)
+    end
   end
 
   # Delegate all HTTP methods to the #request.


### PR DESCRIPTION
This option enables us to connect to a Marathon server using an
invalid (for instance self-signed) certificate.