### PR TITLE
allow `containerPort = 0`

### DIFF
--- a/fixtures/vcr/Marathon/_ping/ping/1_4_1_1.yml
+++ b/fixtures/vcr/Marathon/_ping/ping/1_4_1_1.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/ping
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - ub0r/Marathon-API 1.3.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Content-Type:
+      - text/plain;charset=ISO-8859-1
+      Content-Length:
+      - '5'
+      Server:
+      - Jetty(8.y.z-SNAPSHOT)
+    body:
+      encoding: UTF-8
+      string: |
+        pong
+    http_version: 
+  recorded_at: Wed, 06 Jan 2016 07:55:12 GMT
+recorded_with: VCR 3.0.1

--- a/fixtures/vcr/Marathon_Leader/_delete/delete/1_2_1_1.yml
+++ b/fixtures/vcr/Marathon_Leader/_delete/delete/1_2_1_1.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: http://localhost:8080/v2/leader
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - ub0r/Marathon-API 1.3.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(8.y.z-SNAPSHOT)
+    body:
+      encoding: UTF-8
+      string: '{"message":"Leadership abdicted"}'
+    http_version: 
+  recorded_at: Wed, 06 Jan 2016 07:55:12 GMT
+recorded_with: VCR 3.0.1

--- a/fixtures/vcr/Marathon_Leader/_get/get/1_1_1_1.yml
+++ b/fixtures/vcr/Marathon_Leader/_get/get/1_1_1_1.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/v2/leader
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - ub0r/Marathon-API 1.3.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(8.y.z-SNAPSHOT)
+    body:
+      encoding: UTF-8
+      string: '{"leader":"mesos:8080"}'
+    http_version: 
+  recorded_at: Wed, 06 Jan 2016 07:55:12 GMT
+recorded_with: VCR 3.0.1

--- a/lib/marathon/container_docker_port_mapping.rb
+++ b/lib/marathon/container_docker_port_mapping.rb
@@ -14,8 +14,8 @@ class Marathon::ContainerDockerPortMapping < Marathon::Base
     super(Marathon::Util.merge_keywordized_hash(DEFAULTS, hash), ACCESSORS)
     Marathon::Util.validate_choice('protocol', protocol, %w[tcp udp])
     raise Marathon::Error::ArgumentError, 'containerPort must not be nil' unless containerPort
-    raise Marathon::Error::ArgumentError, 'containerPort must be a positive number' \
-      unless containerPort.is_a?(Integer) and containerPort > 0
+    raise Marathon::Error::ArgumentError, 'containerPort must be a non negative number' \
+      unless containerPort.is_a?(Integer) and containerPort >= 0
     raise Marathon::Error::ArgumentError, 'hostPort must be a non negative number' \
       unless hostPort.is_a?(Integer) and hostPort >= 0
   end

--- a/spec/marathon/container_docker_port_mapping_spec.rb
+++ b/spec/marathon/container_docker_port_mapping_spec.rb
@@ -20,7 +20,7 @@ describe Marathon::ContainerDockerPortMapping do
       expect { subject.new(:containerPort => 'foo') }
         .to raise_error(Marathon::Error::ArgumentError, /containerPort must be/)
       expect { subject.new(:containerPort => 0) }
-        .to raise_error(Marathon::Error::ArgumentError, /containerPort must be/)
+        .not_to raise_error(Marathon::Error::ArgumentError, /containerPort must be/)
       expect { subject.new(:containerPort => -1) }
         .to raise_error(Marathon::Error::ArgumentError, /containerPort must be/)
     end


### PR DESCRIPTION
The marathon docs state that containerPort has a minimum of `0`.

This patch provides a small fix that enables the usage of `containerPort = 0`