### PR TITLE
Marathon::Group#delete returns DeploymentInfo

### DIFF
--- a/lib/marathon/group.rb
+++ b/lib/marathon/group.rb
@@ -124,7 +124,8 @@ Version:    #{version}
     def delete(id, force = false)
       query = {}
       query[:force] = true if force
-      Marathon.connection.delete("/v2/groups/#{id}", query)
+      json = Marathon.connection.delete("/v2/groups/#{id}", query)
+      Marathon::DeploymentInfo.new(json)
     end
     alias :remove :delete
 

--- a/spec/marathon/group_spec.rb
+++ b/spec/marathon/group_spec.rb
@@ -178,7 +178,8 @@ describe Marathon::Group do
     subject { described_class }
 
     it 'deletes the group', :vcr do
-      subject.delete('/test-group', true)
+      expect(subject.delete('/test-group', true))
+        .to be_instance_of(Marathon::DeploymentInfo)
     end
 
     it 'fails deleting not existing app', :vcr do


### PR DESCRIPTION
This commit brings Group#delete in line with the other Group methods, which all return DeploymentInfo objects.

This will be a breaking change for all clients who expect #delete to return a Hash.