### PR TITLE
Marathon::Apps#delete returns DeploymentInfo

### DIFF
--- a/lib/marathon/app.rb
+++ b/lib/marathon/app.rb
@@ -246,7 +246,8 @@ class Marathon::Apps
   # Delete the application with id.
   # ++id++: Application's id.
   def delete(id)
-    @connection.delete("/v2/apps/#{id}")
+    json = @connection.delete("/v2/apps/#{id}")
+    Marathon::DeploymentInfo.new(json)
   end
 
   # Create and start an application.

--- a/spec/marathon/app_spec.rb
+++ b/spec/marathon/app_spec.rb
@@ -339,7 +339,8 @@ describe Marathon::App do
     subject { described_class }
 
     it 'deletes the app', :vcr do
-      subject.delete('/test-app')
+      expect(subject.delete('/test-app'))
+        .to be_instance_of(Marathon::DeploymentInfo)
     end
 
     it 'fails deleting not existing app', :vcr do


### PR DESCRIPTION
Like Group#delete, Apps#delete now returns a DeplomentInfo object.

This will be a breaking change for all clients who expect #delete to
return a Hash.