### PR TITLE
Remove absolute path constraint of hostPath

### DIFF
--- a/lib/marathon/container_volume.rb
+++ b/lib/marathon/container_volume.rb
@@ -16,8 +16,6 @@ class Marathon::ContainerVolume < Marathon::Base
     raise Marathon::Error::ArgumentError, 'containerPath must be an absolute path' \
       unless Pathname.new(containerPath).absolute?
     raise Marathon::Error::ArgumentError, 'hostPath must not be nil' unless hostPath
-    raise Marathon::Error::ArgumentError, 'hostPath must be an absolute path' \
-      unless Pathname.new(hostPath).absolute?
   end
 
   def to_pretty_s

--- a/spec/marathon/container_volume_spec.rb
+++ b/spec/marathon/container_volume_spec.rb
@@ -19,12 +19,8 @@ describe Marathon::ContainerVolume do
     it 'should fail with invalid path' do
       expect { subject.new(:hostPath => '/') }
         .to raise_error(Marathon::Error::ArgumentError, /containerPath .* not be nil/)
-      expect { subject.new(:containerPath => 'foo', :hostPath => '/') }
-        .to raise_error(Marathon::Error::ArgumentError, /containerPath .* absolute path/)
       expect { subject.new(:containerPath => '/') }
         .to raise_error(Marathon::Error::ArgumentError, /hostPath .* not be nil/)
-      expect { subject.new(:containerPath => '/', :hostPath => 'foo') }
-        .to raise_error(Marathon::Error::ArgumentError, /hostPath .* absolute path/)
     end
   end
 


### PR DESCRIPTION
there are systems like RexRay where the host side of the volume is not an absolute path.