### PR TITLE
Add rollback command to the CLI

### DIFF
--- a/bin/marathon
+++ b/bin/marathon
@@ -4,7 +4,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'maratho
 require 'trollop'
 require 'json'
 
-SUB_COMMANDS = %w[kill kill_tasks start scale list list_tasks]
+SUB_COMMANDS = %w[kill kill_tasks start scale rollback list list_tasks]
 ATTRIBUTES = [:id, :cmd, :executor, :instances, :cpus, :mem, :uris]
 DEFAULT_APP_OPTS = {
         :instances => 1,
@@ -121,6 +121,23 @@ def subcmd_kill_tasks(cmd_opts)
   print_tasks(tasks)
 end
 
+def subcmd_rollback(cmd_opts)
+  app = Marathon::App.get(cmd_opts[:id])
+  # Get current versions
+  versions = app.versions
+  # Retrieve N-1 version if none given
+  target = cmd_opts[:version_id] ? cmd_opts[:version_id] : versions[1]
+  # Deploy the target version of the app
+  puts "Rollback app '#{app.id}' from #{versions[0]} to #{target}"
+  app.roll_back!(target, cmd_opts[:force])
+rescue Marathon::Error::MarathonError => e
+  puts "#{e.class}: #{e.message}"
+  exit 1
+rescue TimeoutError => e
+  puts "Deployment took too long"
+  exit 1
+end
+
 # parse global options
 def parse_global_opts
   global_opts = Trollop.options do
@@ -134,6 +151,7 @@ Available commands:
   kill_tasks  Kill a task or tasks belonging to a specified app.
   list        Show a list of running apps and their options.
   list_tasks  Show a list of an app's running tasks.
+  rollback    Rollback an app to a specific version.
   scale       Scale the number of app instances.
   start       Start a new app.
 
@@ -201,6 +219,12 @@ def parse_subcmd_opts(cmd)
         opt :sync, 'Wait for the deployment to finish', :short => '-s'
         opt :timeout, 'Timout for sync call in seconds (default 60).', :type => Integer, :short => '-t'
       end
+    when 'rollback'
+      Trollop.options do
+        opt :id, 'A unique identifier for the app.', :short => '-i', :type => String, :required => true
+        opt :version_id, 'A version identifier.', :short => '-v', :type => String, :default => nil
+        opt :force, 'The current deployment can be overridden by setting the `force`.', :short => '-f'
+      end
     when 'kill'
       Trollop.options do
         opt :id, 'A unique identifier for the app.', :short => '-i', :type => String, :required => true
@@ -238,6 +262,8 @@ def run_subcmd(cmd, cmd_opts)
     subcmd_list_tasks(cmd_opts)
   when 'kill_tasks'
     subcmd_kill_tasks(cmd_opts)
+  when 'rollback'
+    subcmd_rollback(cmd_opts)
   else
     Trollop.die "unknown subcommand #{cmd.inspect}"
   end


### PR DESCRIPTION
So that we are able to quickly rollback to version N-1 or to specify a target version for a dedicated app.