### PR TITLE
Support fetch attribute on the /v2/apps endpoints

### DIFF
--- a/lib/marathon/app.rb
+++ b/lib/marathon/app.rb
@@ -2,7 +2,7 @@
 # See https://mesosphere.github.io/marathon/docs/rest-api.html#apps for full list of API's methods.
 class Marathon::App < Marathon::Base
 
-  ACCESSORS = %w[ id args cmd cpus disk env executor instances mem ports requirePorts
+  ACCESSORS = %w[ id args cmd cpus disk env executor fetch instances mem ports requirePorts
                   storeUris tasksHealthy tasksUnhealthy tasksRunning tasksStaged upgradeStrategy
                   deployments uris user version labels ]
 
@@ -10,7 +10,6 @@ class Marathon::App < Marathon::Base
       :env => {},
       :labels => {},
       :ports => [],
-      :uris => [],
   }
 
   attr_reader :healthChecks, :constraints, :container, :read_only, :tasks
@@ -151,7 +150,7 @@ class Marathon::App < Marathon::Base
   end
 
   def pretty_uris
-    uris.map { |e| "URI:        #{e}" }.join("\n")
+    [ (fetch || []).map { |e| e[:uri] } , uris ].compact.reduce([], :|).map { |e| "URI:        #{e}" }.join("\n")
   end
 
   def pretty_constraints

--- a/spec/marathon/app_spec.rb
+++ b/spec/marathon/app_spec.rb
@@ -12,7 +12,9 @@ describe Marathon::App do
                                       },
                                       'env' => {'FOO' => 'BAR', 'blubb' => 'blah'},
                                       'constraints' => [['hostname', 'UNIQUE']],
-                                      'uris' => ['http://example.com/big.tar'],
+                                      'fetch' => [
+                                        { 'uri' => 'http://example.com/big.tar' },
+                                      ],
                                       'labels' => {'abc' => '123'},
                                       'version' => 'foo-version'
                                   }, double(Marathon::MarathonInstance)) }
@@ -43,7 +45,7 @@ describe Marathon::App do
     subject { described_class.new({'id' => '/app/foo'}, double(Marathon::MarathonInstance)) }
 
     let(:expected_string) do
-      '{"env":{},"labels":{},"ports":[],"uris":[],"id":"/app/foo"}'
+      '{"env":{},"labels":{},"ports":[],"id":"/app/foo"}'
     end
 
     its(:to_json) { should == expected_string }
@@ -153,7 +155,7 @@ describe Marathon::App do
       expect(@subject).to receive(:check_read_only)
       expect(@apps).to receive(:change).with(
           '/app/foo',
-          {:env => {}, :labels => {}, :ports => [], :uris => [], :id => "/app/foo"},
+          {:env => {}, :labels => {}, :ports => [], :id => "/app/foo"},
           false
       )
       @subject.start!
@@ -163,7 +165,7 @@ describe Marathon::App do
       expect(@apps).to receive(:change)
                            .with(
                                '/app/foo',
-                               {:env => {}, :labels => {}, :ports => [], :uris => [], :id => "/app/foo"},
+                               {:env => {}, :labels => {}, :ports => [], :id => "/app/foo"},
                                false
                            )
       @subject.start!


### PR DESCRIPTION
As stated in https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-apps, uris is now deprecated and replaced by fetch.

I also updated the spec tests accordingly.

This is still compatible with the old versions <= 0.15
