### PR TITLE
drop hostpath & absolute containerpath requirements

### DIFF
--- a/lib/marathon/container_volume.rb
+++ b/lib/marathon/container_volume.rb
@@ -13,9 +13,6 @@ class Marathon::ContainerVolume < Marathon::Base
     super(Marathon::Util.merge_keywordized_hash(DEFAULTS, hash), ACCESSORS)
     Marathon::Util.validate_choice('mode', mode, %w[RW RO])
     raise Marathon::Error::ArgumentError, 'containerPath must not be nil' unless containerPath
-    raise Marathon::Error::ArgumentError, 'containerPath must be an absolute path' \
-      unless Pathname.new(containerPath).absolute?
-    raise Marathon::Error::ArgumentError, 'hostPath must not be nil' unless hostPath
   end
 
   def to_pretty_s

--- a/spec/marathon/container_volume_spec.rb
+++ b/spec/marathon/container_volume_spec.rb
@@ -19,8 +19,6 @@ describe Marathon::ContainerVolume do
     it 'should fail with invalid path' do
       expect { subject.new(:hostPath => '/') }
           .to raise_error(Marathon::Error::ArgumentError, /containerPath .* not be nil/)
-      expect { subject.new(:containerPath => '/') }
-          .to raise_error(Marathon::Error::ArgumentError, /hostPath .* not be nil/)
     end
   end
 


### PR DESCRIPTION
persistent volumes use things like this. this means any framework
trying to use persistent disk will make Marathon::App.list blow up.

See the configuration options here for an example:
https://mesosphere.github.io/marathon/docs/persistent-volumes.html
