### PR TITLE
remove ports default

### DIFF
--- a/lib/marathon/app.rb
+++ b/lib/marathon/app.rb
@@ -8,8 +8,7 @@ class Marathon::App < Marathon::Base
 
   DEFAULTS = {
       :env => {},
-      :labels => {},
-      :ports => [],
+      :labels => {}
   }
 
   attr_reader :healthChecks, :constraints, :container, :read_only, :tasks

--- a/spec/marathon/app_spec.rb
+++ b/spec/marathon/app_spec.rb
@@ -45,7 +45,7 @@ describe Marathon::App do
     subject { described_class.new({'id' => '/app/foo'}, double(Marathon::MarathonInstance)) }
 
     let(:expected_string) do
-      '{"env":{},"labels":{},"ports":[],"id":"/app/foo"}'
+      '{"env":{},"labels":{},"id":"/app/foo"}'
     end
 
     its(:to_json) { should == expected_string }
@@ -155,7 +155,7 @@ describe Marathon::App do
       expect(@subject).to receive(:check_read_only)
       expect(@apps).to receive(:change).with(
           '/app/foo',
-          {:env => {}, :labels => {}, :ports => [], :id => "/app/foo"},
+          {:env => {}, :labels => {}, :id => "/app/foo"},
           false
       )
       @subject.start!
@@ -165,7 +165,7 @@ describe Marathon::App do
       expect(@apps).to receive(:change)
                            .with(
                                '/app/foo',
-                               {:env => {}, :labels => {}, :ports => [], :id => "/app/foo"},
+                               {:env => {}, :labels => {}, :id => "/app/foo"},
                                false
                            )
       @subject.start!


### PR DESCRIPTION
Now that ports are deprecated, the default injection of ports=[] into marathon deployments will conflict with anyone using portDefinitions.

This will probably break anyone still using ports.